### PR TITLE
feat: add influxdb support for service and pod

### DIFF
--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/questdb/templates/service.yaml
+++ b/charts/questdb/templates/service.yaml
@@ -11,11 +11,17 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.service.exposePostgreSQL }}
-    - port: {{ .Values.service.port }}
+    {{- if .Values.service.expose.postgresql.enabled }}
+    - port: {{ .Values.service.expose.postgresql.port }}
       targetPort: postgresql
       protocol: TCP
       name: postgresql
+    {{ end }}
+    {{- if .Values.service.expose.influxdb.enabled }}
+    - port: {{ .Values.service.expose.influxdb.port }}
+      targetPort: influxdb
+      protocol: TCP
+      name: influxdb
     {{ end }}
   selector:
     {{- include "questdb.selectorLabels" . | nindent 4 }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -57,6 +57,9 @@ spec:
             - name: postgresql
               containerPort: 8812
               protocol: TCP
+            - name: influxdb
+              containerPort: 9009
+              protocol: TCP
           # QuestDB doesn't really expose an endpoint that works well for
           # these probes. Hopefully soon?
           # livenessProbe:

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -29,7 +29,13 @@ questdb:
 service:
   type: ClusterIP
   port: 80
-  exposePostgreSQL: false
+  expose:
+    postgresql:
+      enabled: false
+      port: 8812
+    influx:
+      enabled: false
+      port: 9009
 
 ## Persist data to a persistent volume
 ##


### PR DESCRIPTION
Hey at all,
this is only a summary of yesterdays @rawkode  live stream about using questdb in k8s. So I wanted only to get this things documented in a way that everyone can use it.

It will change the exposePostgreSQL Parameter as well. So I should it needs a major bump at least ?