### PR TITLE
feat: add headless service

### DIFF
--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: questdb
-version: 0.2.8
+version: 0.3.0
 appVersion: 5.0.6.1
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.io/img/favicon.png

--- a/charts/questdb/templates/headless-svc.yaml
+++ b/charts/questdb/templates/headless-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "questdb.fullname" . }}-headless
+  labels:
+  {{- include "questdb.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgresql
+      port: 8812
+      targetPort: postgresql
+  selector:
+  {{- include "questdb.selectorLabels" . | nindent 4 }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "questdb.selectorLabels" . | nindent 6 }}
-  serviceName: "{{ include "questdb.fullname" . }}"
+  serviceName: "{{ include "questdb.fullname" . }}-headless"
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -71,7 +71,7 @@ spec:
           #     path: /
           #     port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}       
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -1,6 +1,7 @@
 image:
   repository: questdb/questdb
   pullPolicy: IfNotPresent
+  tag: 5.0.6.1-linux-amd64
 
 imagePullSecrets: []
 nameOverride: ""
@@ -18,7 +19,7 @@ questdb:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 9000
   expose:
     postgresql:
       enabled: false


### PR DESCRIPTION
StatefulSets should create a headless service: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations

```
StatefulSets currently require a Headless Service to be responsible for the network identity of the Pods. You are responsible for creating this Service.
```

This will also allow for future integration with Prometheus Postgres exporters (whether deployed externally or via sidecar) 