### PR TITLE
feat: Added Service object annotations

### DIFF
--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: questdb
-version: 0.4.0
+version: 0.5.0
 appVersion: 6.0.1
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.io/img/favicon.png

--- a/charts/questdb/templates/service.yaml
+++ b/charts/questdb/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "questdb.fullname" . }}
   labels:
     {{- include "questdb.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -18,6 +18,7 @@ questdb:
        shared.worker.count: 2
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 9000
   expose:


### PR DESCRIPTION
This feature is needed for example in case when the service is of type LoadBalancer and the LoadBalancer should be an internal one. On azure for example the following annotation is required to use internal LB:

`service.beta.kubernetes.io/azure-load-balancer-internal: "true"`

The service than will look as follows:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: test-questdb
  labels:
    helm.sh/chart: questdb-0.5.0
    app.kubernetes.io/name: questdb
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "6.0.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
spec:
  type: ClusterIP
  ports:
    - port: 9000
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: questdb
    app.kubernetes.io/instance: test
```