### PR TITLE
chore: bump version to 6.0.7.1

### DIFF
--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: questdb
-version: 0.10.0
-appVersion: 6.0.5
+version: 0.11.0
+appVersion: 6.0.7.1
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.io/img/favicon.png
 home: https://questdb.io

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: questdb/questdb
   pullPolicy: IfNotPresent
-  tag: 6.0.5
+  tag: 6.0.7.1
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR bumps the 
* helm chart version to 0.11.0 
* QuestDB version to 6.0.7.1