### PR TITLE
Allows for configurable dataDir via helm chart

### DIFF
--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -39,15 +39,15 @@ spec:
           {{- end }}
           volumeMounts:
           - name: {{ include "questdb.fullname" . }}
-            mountPath: /var/lib/questdb/db
+            mountPath: {{ .Values.questdb.dataDir }}/db
           {{- if .Values.questdb.serverConfig.enabled }}
           - name: server-config
-            mountPath: /var/lib/questdb/conf/server.conf
+            mountPath: {{ .Values.questdb.dataDir }}/conf/server.conf
             subPath: server.conf
           {{- end }}
           {{- if .Values.questdb.loggingConfig.enabled }}
           - name: logging-config
-            mountPath: /var/lib/questdb/conf/log.conf
+            mountPath: {{ .Values.questdb.dataDir }}/conf/log.conf
             subPath: log.conf
           {{- end }}
           ports:

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -12,10 +12,11 @@ podSecurityContext: {}
 securityContext: {}
 
 questdb:
+  dataDir: /var/lib/questdb
   serverConfig:
     enabled: true
     options:
-       shared.worker.count: 2
+      shared.worker.count: 2
   loggingConfig:
     enabled: false
     options: {}


### PR DESCRIPTION
Changing the questdb data dir to `/var/lib/questdb` (as we did in [0.22.0](https://github.com/questdb/questdb-kubernetes/commit/80c4ab591de04a51a1749d71a904a099d077b3a8)) while running versions `< 6.5` could lead to `chown` errors that were resolved in `6.5`.

This change allows users to set the questdb data dir from the helm chart, which updates the mountPath for the `*.conf` configmap volume mounts.

To test, run with the following settings in `values.yaml`:

```
image:
  tag: 6.4.3

questdb:
  dataDir: /root/.questdb
```
