### PR TITLE
Adds prometheus metrics endpoint

### DIFF
--- a/charts/questdb/templates/config-map.yaml
+++ b/charts/questdb/templates/config-map.yaml
@@ -8,6 +8,10 @@ metadata:
 data:
   {{- if .Values.questdb.serverConfig.enabled }}
   server.conf: |
+    {{- if .Values.metrics.enabled }}
+    metrics.enabled = true
+    {{- end }}
+
     {{- range $key, $value := index .Values.questdb.serverConfig.options }}
     {{ $key }} = {{ $value }}
     {{- end }}

--- a/charts/questdb/templates/service.yaml
+++ b/charts/questdb/templates/service.yaml
@@ -1,6 +1,7 @@
 {{ $expose := default dict .Values.service.expose }}
 {{ $influxdb := default dict $expose.influxdb }}
 {{ $postgresql := default dict $expose.postgresql }}
+{{ $metrics := default dict .Values.metrics }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,6 +30,12 @@ spec:
       targetPort: influxdb
       protocol: TCP
       name: influxdb
+    {{ end }}
+    {{- if $metrics.enabled }}
+    - port: {{ $metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
     {{ end }}
   selector:
     {{- include "questdb.selectorLabels" . | nindent 4 }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -63,6 +63,11 @@ spec:
             - name: influxdb
               containerPort: 9009
               protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
           # QuestDB doesn't really expose an endpoint that works well for
           # these probes. Hopefully soon?
           # livenessProbe:

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -63,3 +63,7 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+metrics:
+  enabled: true
+  port: 9003


### PR DESCRIPTION
You can enable the metrics endpoint by setting the following in a `values.yaml`:
```
---
metrics:
  enabled: true
```