### PR TITLE
feat(chart): [#110] allow adding sidecar containers

### DIFF
--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -80,6 +80,9 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecars  }}
+          {{- toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -67,3 +67,5 @@ affinity: {}
 metrics:
   enabled: true
   port: 9003
+
+sidecars: []


### PR DESCRIPTION
This resolves https://github.com/questdb/questdb-kubernetes/issues/110 by allowing additional containers to be added as sidecars to the statefulset.