### PR TITLE
feat(chart): add PG username and password as environment variables

### DIFF
--- a/charts/questdb/templates/_helpers.tpl
+++ b/charts/questdb/templates/_helpers.tpl
@@ -24,6 +24,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -59,5 +60,13 @@ Create the name of the service account to use
 {{- default (include "questdb.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "questdb.pgSecretName" -}}
+{{- if .Values.existingSecrets }}
+{{- .Values.existingSecrets.pgSecretName }}
+{{- else }}
+{{-  printf "%s-%s" (include "questdb.fullname" .) "pg-secret" -}}
 {{- end }}
 {{- end }}

--- a/charts/questdb/templates/_helpers.tpl
+++ b/charts/questdb/templates/_helpers.tpl
@@ -70,3 +70,35 @@ Create the name of the service account to use
 {{-  printf "%s-%s" (include "questdb.fullname" .) "pg-secret" -}}
 {{- end }}
 {{- end }}
+
+{{- define "questdb.pgSecretUserKey" -}}
+{{- if .Values.existingSecrets }}
+{{- .Values.existingSecrets.pgSecretUserKey }}
+{{- else }}
+{{- default "username" -}}
+{{- end }}
+{{- end }}
+
+{{- define "questdb.pgSecretPasswordKey" -}}
+{{- if .Values.existingSecrets }}
+{{- .Values.existingSecrets.pgSecretPasswordKey }}
+{{- else }}
+{{- default "password" -}}
+{{- end }}
+{{- end }}
+
+{{- define "questdb.pgSecretReadOnlyUserKey" -}}
+{{- if .Values.existingSecrets }}
+{{- .Values.existingSecrets.pgSecretReadOnlyUserKey }}
+{{- else }}
+{{- default "readonly-username" -}}
+{{- end }}
+{{- end }}
+
+{{- define "questdb.pgSecretReadOnlyPasswordKey" -}}
+{{- if .Values.existingSecrets }}
+{{- .Values.existingSecrets.pgSecretReadOnlyPasswordKey }}
+{{- else }}
+{{- default "readonly-password" -}}
+{{- end }}
+{{- end }}

--- a/charts/questdb/templates/secret.yaml
+++ b/charts/questdb/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.generateSecrets.psqlSecret.enabled }}
+{{- if and .Values.generateSecrets.psqlSecret.enabled (not .Values.existingSecrets) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/questdb/templates/secret.yaml
+++ b/charts/questdb/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.generateSecrets.psqlSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "questdb.pgSecretName" . }}
+type: Opaque
+data:
+  username: {{ "admin" | b64enc | quote }}
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (include "questdb.pgSecretName" .)) | default dict }}
+  {{- $secretData := (get $secretObj "data") | default dict }}
+  {{- $psqlPassword := (get $secretData "password") | default (randAlphaNum 32 | b64enc) }}
+  password: {{ $psqlPassword | quote }}
+  {{- if .Values.generateSecrets.psqlSecret.enableReadOnlyUser }}
+  readonly-username: {{ "user" | b64enc | quote }}
+  {{- $readonlypsqlPassword := (get $secretData "readonly-password") | default (randAlphaNum 32 | b64enc) }}
+  readonly-password: {{ $readonlypsqlPassword | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -41,26 +41,26 @@ spec:
             - name: QDB_PG_USER
               valueFrom:
                 secretKeyRef:
-                  key: username
+                  key: {{ include "questdb.pgSecretUserKey" . }}
                   name: {{ include "questdb.pgSecretName" . }}
                   optional: false
             - name: QDB_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: password
+                  key: {{ include "questdb.pgSecretPasswordKey" . }}
                   name: {{ include "questdb.pgSecretName" . }}
                   optional: false
             {{- if or .Values.generateSecrets.psqlSecret.enableReadOnlyUser .Values.existingSecrets.enableReadOnlyUser }}
             - name: QDB_PG_READONLY_USER
               valueFrom:
                 secretKeyRef:
-                  key: readonly-username
+                  key: {{ include "questdb.pgSecretReadOnlyUserKey" . }}
                   name: {{ include "questdb.pgSecretName" . }}
                   optional: false
             - name: QDB_PG_READONLY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: readonly-password
+                  key: {{ include "questdb.pgSecretReadOnlyPasswordKey" . }}
                   name: {{ include "questdb.pgSecretName" . }}
                   optional: false
             {{- end }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -37,6 +37,34 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
           {{- end }}
+          {{- if or .Values.generateSecrets.psqlSecret.enabled .Values.existingSecrets }}
+            - name: QDB_PG_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: {{ include "questdb.pgSecretName" . }}
+                  optional: false
+            - name: QDB_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: {{ include "questdb.pgSecretName" . }}
+                  optional: false
+            {{- if or .Values.generateSecrets.psqlSecret.enableReadOnlyUser .Values.existingSecrets.enableReadOnlyUser }}
+            - name: QDB_PG_READONLY_USER
+              valueFrom:
+                secretKeyRef:
+                  key: readonly-username
+                  name: {{ include "questdb.pgSecretName" . }}
+                  optional: false
+            - name: QDB_PG_READONLY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: readonly-password
+                  name: {{ include "questdb.pgSecretName" . }}
+                  optional: false
+            {{- end }}
+          {{- end }}
           volumeMounts:
           - name: {{ include "questdb.fullname" . }}
             mountPath: {{ .Values.questdb.dataDir }}/db

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -77,4 +77,8 @@ generateSecrets:
 
 existingSecrets: {}
   # pgSecretName: psql-secret
+  # pgSecretUserKey: username
+  # pgSecretPasswordKey: password
   # enableReadOnlyUser: false
+  # pgSecretReadOnlyUserKey: readonly-username
+  # pgSecretReadOnlyPasswordKey: readonly-password

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -69,3 +69,12 @@ metrics:
   port: 9003
 
 sidecars: []
+
+generateSecrets:
+  psqlSecret:
+    enabled: false
+    enableReadOnlyUser: false
+
+existingSecrets: {}
+  # pgSecretName: psql-secret
+  # enableReadOnlyUser: false


### PR DESCRIPTION
The following flags will generate random passwords:
```yaml
generateSecrets:
  psqlSecret:
    enabled: true
    enableReadOnlyUser: true
```
`enableReadOnlyUser` will generate and add environment variables for read-only user also

One can provide already a secret name as following:
```yaml
existingSecrets: {}
  pgSecretName: psql-secret
  enableReadOnlyUser: true
```
`enableReadOnlyUser` as `true` will add read-only username and password to env variable

The secret should look like this:
```yaml
apiVersion: v1
data:
  username: BASE_64_ENCODED_USER
  password: BASE_64_ENCODED_PASSWORD
  # only needed if you set enableReadOnlyUser as true
  readonly-username: BASE_64_ENCODED_USER
  readonly-password: BASE_64_ENCODED_PASSWORD
kind: Secret
metadata:
  name: psql-secret
  namespace: questdb
type: Opaque
```