### PR TITLE
Fix typo in values.yaml comments

### DIFF
--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -45,7 +45,7 @@ persistence:
   # storageClassName: STORAGE_CLASS_NAME_HERE
   # Uncomment existingClaim to enable existing pvc to be mounted for db storage
   # size and accessMode will be ignored
-  # existiung pvc needs to be in the namespace where questdb will be deployed
+  # existing pvc needs to be in the namespace where questdb will be deployed
   # if you have problems with aws availability zones use nodeSelector to schedule nodes in the same az as volume
   # existingClaim: PVC_NAME_HERE
 


### PR DESCRIPTION
Fixes the typo from `existiung` to `existing` in values.yaml for better readability of comments