### PR TITLE
fix: correct the variable name for storageClass

### DIFF
--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -42,7 +42,7 @@ persistence:
   size: 50Gi
   annotations: {}
   # Uncomment storageClass if you want to use a specific Storage Class
-  # storageClassName: STORAGE_CLASS_NAME_HERE
+  # storageClass: STORAGE_CLASS_NAME_HERE
   # Uncomment existingClaim to enable existing pvc to be mounted for db storage
   # size and accessMode will be ignored
   # existing pvc needs to be in the namespace where questdb will be deployed


### PR DESCRIPTION
Fixes the variable name from `storageClassName` to `storageClass` in `charts/questdb/values.yaml`:
https://github.com/questdb/questdb-kubernetes/blob/3d02103256d95bf02fd6a0a497034c1e21472c6f/charts/questdb/values.yaml#L44-L45

This variable `(.Values.persistence.storageClass)` is being referenced in `charts/questdb/templates/statefulsets.yaml` :
https://github.com/questdb/questdb-kubernetes/blob/3d02103256d95bf02fd6a0a497034c1e21472c6f/charts/questdb/templates/statefulset.yaml#L133-L137

**Quick Context:**
By default, the persistent volume claim utilizes the `ebs` storage class. However, for my specific use case, I needed to employ the `efs` storage class. Therefore, when I attempted to set the `storageClassName` variable in accordance with the instructions in the `values.yaml` file, there was no modification observed in the PVC. It continued to utilize the default `ebs` storage class.

Upon further examination, I discovered that the correct variable name is actually `storageClass`, rather than `storageClassName`. It is important to update this information to prevent any potential confusion or misdirection for new users reading the comments.

@sklarsa @bluestreak01 @mariusgheorghies: Please review and approve the PR!