### PR TITLE
Add support for liveness and readiness probe

### DIFF
--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -78,16 +78,14 @@ spec:
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
             {{- end }}
-          # QuestDB doesn't really expose an endpoint that works well for
-          # these probes. Hopefully soon?
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          {{- if .Values.livenessProbe  }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe  }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.sidecars  }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           {{- end }}
-          {{- if .Values.livenessProbe  }}
+          {{- if .Values.readinessProbe  }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           {{- end }}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -70,6 +70,29 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+readinessProbe: {}
+  # Example of readinessProbe
+  # failureThreshold: 3
+  # httpGet:
+  #   path: /status
+  #   port: 9003
+  #   scheme: HTTP
+  # initialDelaySeconds: 5
+  # periodSeconds: 10
+  # successThreshold: 1
+  # timeoutSeconds: 2
+livenessProbe: {}
+  # Example of livenessProbe
+  # failureThreshold: 5
+  # httpGet:
+  #   path: /status
+  #   port: 9003
+  #   scheme: HTTP
+  # initialDelaySeconds: 5
+  # periodSeconds: 10
+  # successThreshold: 1
+  # timeoutSeconds: 2
+
 
 metrics:
   enabled: true


### PR DESCRIPTION
It should have no impact for already deployed pods because by default we don't enable the `livenessProbe` and `readinessProbe`