### PR TITLE
Ingress pathType is now configurable

### DIFF
--- a/charts/questdb/templates/ingress.yaml
+++ b/charts/questdb/templates/ingress.yaml
@@ -37,9 +37,9 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
             {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: ImplementationSpecific
+            pathType: {{ default "ImplementationSpecific" .pathType | quote }}
             {{- end }}
             backend:
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -53,4 +53,4 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -64,7 +64,8 @@ ingress:
   # hosts:
   #   - host: example.com
   #     paths:
-  #       - /
+  #       - path: /
+  #         pathType: ImplementationSpecific
 
 resources: {}
 nodeSelector: {}


### PR DESCRIPTION
#154 Enabled customization of the pathType for each ingress route in the Helm chart.
This change allows defining specific PathTypes (such as Prefix, Exact, or ImplementationSpecific) in the values.yaml