### PR TITLE
fix: Enables CHECKPOINT operations

### DIFF
--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "questdb.labels" . | nindent 4 }}
 data:
     migrate_to_helm_v1.sh: |
-      #!/bin/bash
+      #!/bin/sh
 
       set -e
 

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -6,22 +6,51 @@ metadata:
     {{- include "questdb.labels" . | nindent 4 }}
 data:
     migrate_to_helm_v1.sh: |
-      #!/bin/sh
+      #!/bin/bash
 
-      set -e
+      set -e 
+      shopt -s extglob
 
       SOURCE_DIR="/mnt/questdb"
-      DEST_DIR="/mnt/questdb/db"
+      DEST_DIR="db"
+      TEMP_DIR="db_helm_migration_1_tmp_$(date +"%Y%m%d%H%M%S")"
       MARKER="tables.d.0"
 
-      # Ensure the destination directory exists
-      mkdir -p "$DEST_DIR"
+      cd $SOURCE_DIR
 
-      # Check if the specific file exists
-      if [[ -f "$SOURCE_DIR/$MARKER" ]]; then
-          echo "File '$MARKER' found. Moving contents of $SOURCE_DIR to $DEST_DIR."
-          mv "$SOURCE_DIR"/* "$DEST_DIR/"
-          echo "Migrated persistent volume data to be compatible with QuestDB helm chart versions v1+"
-      else
-          echo "File '$MARKER' not found. Nothing to move."
+      if [[ ! -e $MARKER ]] ; then
+        echo "File '$MARKER' not found. Nothing to move."
+        exit 0
       fi
+
+      # If the db dir already exists, move its contents to a temp dir
+      if [[ -e $DEST_DIR ]]; then
+        
+        # Check that the temp dir does not already exist. This is highly 
+        # unlikely and we fail if this is the case
+        if [[ -e $TEMP_DIR ]]; then
+          echo "$TEMP_DIR exists! exiting data migration"
+          exit 1
+        fi 
+
+        # Move the existing db dir to the temp location
+        mv "$DEST_DIR" "$TEMP_DIR"
+
+      fi
+ 
+      # Make the target db dir
+      mkdir $DEST_DIR
+
+      # Move all regular files into the db dir
+      mv !($DEST_DIR) $DEST_DIR
+
+      # Move any hidden files
+      mv .[^.]* "$DEST_DIR/" 2>/dev/null || true
+
+      # Check if the temp dir exists in the new location, if so, move it back to db/db
+      if [[ -d "$DEST_DIR/$TEMP_DIR" ]]; then
+        mv $DEST_DIR/$TEMP_DIR $DEST_DIR/$DEST_DIR
+      fi
+
+      echo "Migration complete!"
+

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -10,12 +10,16 @@ data:
 
       set -e
 
+      ls -lah $SOURCE_DIR
+
+      exit 1
+
       SOURCE_DIR="/mnt/questdb"
-      DEST_DIR="/mnt/questdb/abracadabra"
+      DEST_DIR="/mnt/questdb/db"
 
       MARKER="tables.d.0"
 
-      ls -lah $SOURCE_DIR
+
 
       # Ensure the destination directory exists
       mkdir -p "$DEST_DIR"

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -10,21 +10,12 @@ data:
 
       set -e
 
-      ls -lah $SOURCE_DIR
-
-      exit 1
-
       SOURCE_DIR="/mnt/questdb"
       DEST_DIR="/mnt/questdb/db"
-
       MARKER="tables.d.0"
-
-
 
       # Ensure the destination directory exists
       mkdir -p "$DEST_DIR"
-
-      ls -lah $SOURCE_DIR
 
       # Check if the specific file exists
       if [[ -f "$SOURCE_DIR/$MARKER" ]]; then

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -11,9 +11,11 @@ data:
       set -e
 
       SOURCE_DIR="/mnt/questdb"
-      DEST_DIR="/mnt/questdb/db"
+      DEST_DIR="/mnt/questdb/abracadabra"
 
       MARKER="tables.d.0"
+
+      ls -lah $SOURCE_DIR
 
       # Ensure the destination directory exists
       mkdir -p "$DEST_DIR"
@@ -28,5 +30,3 @@ data:
       else
           echo "File '$MARKER' not found. Nothing to move."
       fi
-
-      

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -18,6 +18,8 @@ data:
       # Ensure the destination directory exists
       mkdir -p "$DEST_DIR"
 
+      ls -lah $SOURCE_DIR
+
       # Check if the specific file exists
       if [[ -f "$SOURCE_DIR/$MARKER" ]]; then
           echo "File '$MARKER' found. Moving contents of $SOURCE_DIR to $DEST_DIR."

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "questdb.fullname" . }}-db-migrations
+  labels:
+    {{- include "questdb.labels" . | nindent 4 }}
+data:
+    migrate_to_helm_v1.sh: |
+      #!/bin/bash
+
+      set -e
+
+      SOURCE_DIR="/mnt/questdb"
+      DEST_DIR="/mnt/questdb/db"
+
+      MARKER="tables.d.0"
+
+      # Ensure the destination directory exists
+      mkdir -p "$DEST_DIR"
+
+      # Check if the specific file exists
+      if [[ -f "$SOURCE_DIR/$MARKER" ]]; then
+          echo "File '$MARKER' found. Moving contents of $SOURCE_DIR to $DEST_DIR."
+          mv "$SOURCE_DIR"/* "$DEST_DIR/"
+          echo "Migrated persistent volume data to be compatible with QuestDB helm chart versions v1+"
+      else
+          echo "File '$MARKER' not found. Nothing to move."
+      fi
+
+      

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -51,6 +51,10 @@ spec:
           volumeMounts:
           - name: {{ include "questdb.fullname" . }}
             mountPath: {{ .Values.questdb.dataDir }}/db
+            subPath: db/
+          - name: {{ include "questdb.fullname" . }}
+            mountPath: {{ .Values.questdb.dataDir }}/.checkpoint
+            subPath: .checkpoint/
           {{- if .Values.questdb.serverConfig.enabled }}
           - name: server-config
             mountPath: {{ .Values.questdb.dataDir }}/conf/server.conf
@@ -92,8 +96,16 @@ spec:
         {{- if .Values.sidecars  }}
           {{- toYaml .Values.sidecars | nindent 8 }}
         {{- end }}
-      {{- if .Values.initContainers  }}
       initContainers:
+        - name: init-db-migration
+          image: busybox:1.37.0
+          command: ["sh", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
+          volumeMounts:
+            - name: {{ include "questdb.fullname" . }}
+              mountPath: /mnt/questdb
+            - name: migration-scripts
+              mountPath: /mnt/migration_scripts  
+      {{- if .Values.initContainers  }}
         {{- toYaml .Values.initContainers | nindent 6 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
@@ -129,6 +141,9 @@ spec:
             name: {{ include "questdb.fullname" . }}
           {{- end }}
         {{- end }}
+        - name: migration-scripts
+          configMap:
+            name: {{ include "questdb.fullname" . }}-db-migrations
         {{- if .Values.extraVolumes }}
           {{ toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -55,6 +55,9 @@ spec:
           - name: {{ include "questdb.fullname" . }}
             mountPath: {{ .Values.questdb.dataDir }}/.checkpoint
             subPath: .checkpoint/
+          - name: {{ include "questdb.fullname" . }}
+            mountPath: {{ .Values.questdb.dataDir }}/snapshot
+            subPath: snapshot/
           {{- if .Values.questdb.serverConfig.enabled }}
           - name: server-config
             mountPath: {{ .Values.questdb.dataDir }}/conf/server.conf

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
         {{- end }}
       initContainers:
         - name: init-db-migration
-          image: busybox:1.37.0
+          image: debian:bookworm-slim
           command: ["sh", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
           volumeMounts:
             - name: {{ include "questdb.fullname" . }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
       initContainers:
         - name: init-db-migration
           image: debian:bookworm-slim
-          command: ["sh", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
+          command: ["bash", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
           volumeMounts:
             - name: {{ include "questdb.fullname" . }}
               mountPath: /mnt/questdb


### PR DESCRIPTION
Because we mount the QuestDB Pod's `/var/lib/questdb/db` subdir directly to the persistent volume root, we don't end up storing the contents of `./.checkpoint` (or `./snapshot` if using legacy `SNAPSHOT ...` syntax) in the persistent volume. This makes it impossible to recover from a snapshot of the persistent volume unless the files are manually copied from the old pod to the new one before `CHECKPOINT RELEASE` has been run, which is difficult to achieve.

This PR changes 2 things:
1. Re-mounts the PV to `/var/lib/questdb/db` using [a subpath](https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath), which directly maps the `./db/` dir in the PV to the Pod's `./db/` dir. This way, we can mount the root of the volume at `/var/lib/questdb` and persist other directories at the db root (`/var/lib/questdb`).
2. To migrate existing users, I've added an init container which runs before QuestDB is initialized. It looks for a marker that tells us the PV is mounted to the Pod's `./db/` dir (I use `tables.d.0`, but maybe @bluestreak01 or @nwoolmer have better ideas). If this marker is found, it creates a `./db/` subdir and moves all content on the volume to that subdir. This way, our subpath mount in the previous point will be pointing to the correct directory in the PV. As long as users don't manually add the marker to the db root at a later time, this should only run once.

I've tested this locally using kind, but since this is a very sensitive operation, I'm going to perform additional testing next week.