### PR TITLE
Data migration templating fixes

### DIFF
--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -100,8 +100,8 @@ spec:
           {{- toYaml .Values.sidecars | nindent 8 }}
         {{- end }}
       initContainers:
-        - name: "{{ .Values.dataMigration.image }}"
-          image: debian:bookworm-slim
+        - name: init-db-migration
+          image: "{{ .Values.dataMigration.image }}"
           command: ["bash", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
           volumeMounts:
             - name: {{ include "questdb.fullname" . }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
           {{- toYaml .Values.sidecars | nindent 8 }}
         {{- end }}
       initContainers:
-        - name: init-db-migration
+        - name: "{{ .Values.dataMigration.image }}"
           image: debian:bookworm-slim
           command: ["bash", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
           volumeMounts:
@@ -108,6 +108,10 @@ spec:
               mountPath: /mnt/questdb
             - name: migration-scripts
               mountPath: /mnt/migration_scripts  
+      {{- if .Values.dataMigration.resources }}
+          resources:
+            {{- toYaml .Values.dataMigration.resources | nindent 12}}
+      {{- end }}
       {{- if .Values.initContainers  }}
         {{- toYaml .Values.initContainers | nindent 6 }}
       {{- end }}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -111,3 +111,11 @@ serviceAccount:
   # if create is set to "true", you can specify the name of that service account below
   # if create is set to "false", you can use this to reference an existing service account for the StatefulSet pod
   # name: custom-service-account-name
+
+dataMigration:
+  image: "debian:bookworm-slim"
+  resources:
+    requests:
+      memory: "256Mi"
+    limits:
+      memory: "1Gi"


### PR DESCRIPTION
Adds customization options for the following:
1. Data migration container image (defaults to `debian:bookworm-slim`)
2. Data migration container resources (defaults to 256Mi mem request and 1Gi mem limit)

To Test...
1. Create a new `kind` cluster
2. cd to the root of this repo
3. `helm upgrade --install questdb ./charts/questdb`
4. Validate that the command succeeded
5. Change variables in `./charts/questdb/values.yaml` and rerun the `helm upgrade ...` command