### PR TITLE
Remove sample config line from values.yaml

### DIFF
--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -18,9 +18,8 @@ questdb:
   dataDir: /var/lib/questdb
   configStorageType: ConfigMap
   serverConfig:
-    enabled: true
-    options:
-      shared.worker.count: 2
+    enabled: false
+    options: {}
   loggingConfig:
     enabled: false
     options: {}


### PR DESCRIPTION
If users were running the helm chart as-is, we pinned shared worker count to 2. This disables the server config by default.