### PR TITLE
Pod security updates and Helm push

### DIFF
--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: questdb
-version: 1.0.2
-appVersion: 8.2.3
+version: 1.0.3
+appVersion: 8.3.0
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.com/img/favicon.png
 home: https://questdb.com

--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: questdb
-version: 1.0.5
-appVersion: 8.3.1
+version: 1.0.7
+appVersion: 8.3.3
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.com/img/favicon.png
 home: https://questdb.com

--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: questdb
-version: 1.0.4
-appVersion: 8.3.0
+version: 1.0.5
+appVersion: 8.3.1
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.com/img/favicon.png
 home: https://questdb.com

--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: questdb
-version: 1.0.1
+version: 1.0.2
 appVersion: 8.2.3
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.com/img/favicon.png

--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -6,7 +6,7 @@ description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.com/img/favicon.png
 home: https://questdb.com
 sources:
-  - https://helm.questdb.io/
+  - https://github.com/questdb/questdb-kubernetes/
 type: application
 keywords:
   - questdb

--- a/charts/questdb/Chart.yaml
+++ b/charts/questdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: questdb
-version: 1.0.3
+version: 1.0.4
 appVersion: 8.3.0
 description: Run QuestDB on Kubernetes via Helm
 icon: https://questdb.com/img/favicon.png

--- a/charts/questdb/templates/_helpers.tpl
+++ b/charts/questdb/templates/_helpers.tpl
@@ -79,3 +79,45 @@ Generate log.conf file content
 {{ $key }} = {{ $value }}
 {{- end }}
 {{- end }}
+
+{{/*
+Build openshift detection
+*/}}
+{{- define "isOpenshiftEnabled" -}}
+{{- $openshiftEnabledString := (.Values.openshift).enabled | toString -}}
+{{- if eq $openshiftEnabledString "true" -}}
+true
+{{- else if and (eq $openshiftEnabledString "detect") (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+true
+{{- end }}
+{{- end }}
+
+{{/*
+Build securityContext
+*/}}
+{{- define "generateSecurityContext" -}}
+{{- $context := .Values.securityContext -}}
+{{- if $context -}}
+{{- if (include "isOpenshiftEnabled" .) -}}
+{{- $context = omit $context "runAsUser" "runAsGroup" "fsGroup" -}}
+{{- end -}}
+{{- else -}}
+{{ $context = dict -}}
+{{- end -}}
+{{ $context | toYaml }}
+{{- end }}
+
+{{/*
+Build podSecurityContext
+*/}}
+{{- define "generatePodSecurityContext" -}}
+{{- $context := .Values.podSecurityContext -}}
+{{- if $context -}}
+{{- if (include "isOpenshiftEnabled" .) -}}
+{{- $context = omit $context "runAsUser" "runAsGroup" "fsGroup" -}}
+{{- end -}}
+{{- else -}}
+{{ $context = dict -}}
+{{- end -}}
+{{ $context | toYaml }}
+{{- end }}

--- a/charts/questdb/templates/_helpers.tpl
+++ b/charts/questdb/templates/_helpers.tpl
@@ -81,6 +81,15 @@ Generate log.conf file content
 {{- end }}
 
 {{/*
+Generate mime.types file content
+*/}}
+{{- define "generateMimeConfig" -}}
+{{- range $key, $value := index .Values.questdb.mimeConfig.options }}
+{{ $key }}   {{ $value }}
+{{- end }}
+{{- end }}
+
+{{/*
 Build openshift detection
 */}}
 {{- define "isOpenshiftEnabled" -}}

--- a/charts/questdb/templates/config.yaml
+++ b/charts/questdb/templates/config.yaml
@@ -18,6 +18,9 @@ data:
   {{- if .Values.questdb.loggingConfig.enabled }}
   log.conf: {{ include "generateLogConfig" . | b64enc -}}
   {{- end }}
+  {{- if .Values.questdb.mimeConfig.enabled }}
+  mime.types: {{ include "generateMimeConfig" . | b64enc -}}
+  {{- end }}
 {{- else }}
 data:
   {{- if .Values.questdb.serverConfig.enabled }}
@@ -27,6 +30,10 @@ data:
   {{- if .Values.questdb.loggingConfig.enabled }}
   log.conf: |
     {{- include "generateLogConfig" . | nindent 4 -}}
+  {{- end }}
+  {{- if .Values.questdb.mimeConfig.enabled }}
+  mime.types: |
+    {{- include "generateMimeConfig" . | nindent 4 -}}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/questdb/templates/serviceaccount.yaml
+++ b/charts/questdb/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
     name: {{ include "questdb.serviceAccountName" . }}
     {{- if .Values.serviceAccount.labels }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -52,8 +52,10 @@ spec:
           volumeMounts:
           - name: tmpfs-tmp
             mountPath: /tmp
-          - name: tmpfs-questdb
-            mountPath: /var/lib/questdb
+          - name: tmpfs-questdb-import
+            mountPath: /var/lib/questdb/import
+          - name: tmpfs-questdb-public
+            mountPath: /var/lib/questdb/public
           - name: {{ include "questdb.fullname" . }}
             mountPath: {{ .Values.questdb.dataDir }}/db
             subPath: db/
@@ -72,6 +74,11 @@ spec:
           - name: logging-config
             mountPath: {{ .Values.questdb.dataDir }}/conf/log.conf
             subPath: log.conf
+          {{- end }}
+          {{- if .Values.questdb.mimeConfig.enabled }}
+          - name: mime-config
+            mountPath: {{ .Values.questdb.dataDir }}/conf/mime.types
+            subPath: mime.types
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
@@ -137,7 +144,9 @@ spec:
       volumes:
         - name: tmpfs-tmp
           emptyDir: {}
-        - name: tmpfs-questdb
+        - name: tmpfs-questdb-import
+          emptyDir: {}
+        - name: tmpfs-questdb-public
           emptyDir: {}
         {{- if .Values.questdb.serverConfig.enabled }}
         - name: server-config
@@ -151,6 +160,16 @@ spec:
         {{- end }}
         {{- if .Values.questdb.loggingConfig.enabled }}
         - name: logging-config
+          {{- if eq .Values.questdb.configStorageType "Secret" }}
+          secret:
+              secretName: {{ include "questdb.fullname" . }}
+          {{- else }}
+          configMap:
+            name: {{ include "questdb.fullname" . }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.questdb.mimeConfig.enabled }}
+        - name: mime-config
           {{- if eq .Values.questdb.configStorageType "Secret" }}
           secret:
               secretName: {{ include "questdb.fullname" . }}

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- include "generatePodSecurityContext" . | nindent 8 }}
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "questdb.serviceAccountName" . }}
       {{- end }}
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- include "generateSecurityContext" . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
@@ -109,7 +109,7 @@ spec:
           image: "{{ .Values.dataMigration.image.repository }}:{{ .Values.dataMigration.image.tag }}"
           command: ["bash", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- include "generateSecurityContext" . | nindent 12 }}
           volumeMounts:
             - name: {{ include "questdb.fullname" . }}
               mountPath: /mnt/questdb

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
             {{- toYaml .Values.dataMigration.resources | nindent 12}}
       {{- end }}
       {{- if .Values.initContainers  }}
-        {{- toYaml .Values.initContainers | nindent 6 }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "questdb.serviceAccountName" . }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -49,6 +50,10 @@ spec:
             {{ toYaml .Values.questdb.envFrom | nindent 10 }}
           {{- end }}
           volumeMounts:
+          - name: tmpfs-tmp
+            mountPath: /tmp
+          - name: tmpfs-questdb
+            mountPath: /var/lib/questdb
           - name: {{ include "questdb.fullname" . }}
             mountPath: {{ .Values.questdb.dataDir }}/db
             subPath: db/
@@ -103,6 +108,8 @@ spec:
         - name: init-db-migration
           image: "{{ .Values.dataMigration.image.repository }}:{{ .Values.dataMigration.image.tag }}"
           command: ["bash", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: {{ include "questdb.fullname" . }}
               mountPath: /mnt/questdb
@@ -128,6 +135,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmpfs-tmp
+          emptyDir: {}
+        - name: tmpfs-questdb
+          emptyDir: {}
         {{- if .Values.questdb.serverConfig.enabled }}
         - name: server-config
           {{- if eq .Values.questdb.configStorageType "Secret" }}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: questdb/questdb
   pullPolicy: IfNotPresent
-  tag: 8.2.3
+  tag: 8.3.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: questdb/questdb
   pullPolicy: IfNotPresent
-  tag: 8.3.1
+  tag: 8.3.3
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -39,6 +39,9 @@ questdb:
   loggingConfig:
     enabled: false
     options: {}
+  mimeConfig:
+    enabled: false
+    options: {}
   # env supports key/value pairs that are added directly to the questdb statefulset's env
   env: {}
   # envFrom supports a list of sources that will be injected into the questdb statefulset's env

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -18,9 +18,8 @@ questdb:
   dataDir: /var/lib/questdb
   configStorageType: ConfigMap
   serverConfig:
-    enabled: true
-    options:
-      shared.worker.count: 2
+    enabled: false
+    options: {}
   loggingConfig:
     enabled: false
     options: {}

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: questdb/questdb
   pullPolicy: IfNotPresent
-  tag: 8.3.0
+  tag: 8.3.1
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -139,3 +139,8 @@ dataMigration:
       memory: "256Mi"
     limits:
       memory: "1Gi"
+
+# openshift
+openshift:
+  enabled: detect
+

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -8,8 +8,24 @@ nameOverride: ""
 fullnameOverride: ""
 
 podAnnotations: {}
-podSecurityContext: {}
-securityContext: {}
+podSecurityContext:
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  privileged: false
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+
 extraVolumes: []
 extraVolumeMounts: []
 extraLabels: {}
@@ -94,6 +110,7 @@ livenessProbe: {}
   # successThreshold: 1
   # timeoutSeconds: 2
 
+automountServiceAccountToken: false
 
 metrics:
   enabled: true
@@ -106,6 +123,7 @@ serviceAccount:
   create: false
   labels: {}
   annotations: {}
+  automountServiceAccountToken: false
 
   # if create is set to "true", you can specify the name of that service account below
   # if create is set to "false", you can use this to reference an existing service account for the StatefulSet pod


### PR DESCRIPTION
This PR contains a few changes we worked.  These changes enable the container to run more securely by-default.

1. Security improvements: Pod Security Restricted support
2. Security improvements: Ability to run with read only root filesystem in the container (immutable container). This includes making mimeConfig configurable
3. Security improvements: Do not automount security account (automountServiceAccountToken)
4. Security improvement: Customization for OpenShift support
5. Add GitHub build plan action to publish the Helm chart to the GitHub Container Registry. This allows pulling chart releases from OCI compliant tools/registries

Please reach out if you have questions.