### PR TITLE
use slimmer image for init container

### DIFF
--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -39,7 +39,7 @@ data:
       fi
 
       # Make the target db dir
-      mkdir "$DEST_DIR"
+      mkdir -p "$DEST_DIR"
 
       # Move all visible files and dirs (except db) into the db dir
       for item in ./* ; do

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -16,7 +16,7 @@ data:
       TEMP_DIR="db_helm_migration_1_tmp_$(date +"%Y%m%d%H%M%S")"
       MARKER="tables.d.*"
 
-      cd $SOURCE_DIR
+      cd "$SOURCE_DIR"
 
       if [ -z "$(ls $MARKER 2>/dev/null)" ] ; then
         echo "File '$MARKER' not found. Nothing to move."
@@ -42,10 +42,16 @@ data:
       mkdir "$DEST_DIR"
 
       # Move all visible files and dirs (except db) into the db dir
-      find . -maxdepth 1 ! -name '.' ! -name "$DEST_DIR" ! -name '.*' -exec mv {} "$DEST_DIR/" \;
+      for item in ./* ; do
+        [ "$(basename "$item")" = "$DEST_DIR" ] && continue
+        mv "$item" "$DEST_DIR/"
+      done
 
       # Move any hidden files
-      find . -maxdepth 1 -name '.*' ! -name '.' ! -name '..' -exec mv {} "$DEST_DIR/" \;
+      for item in ./.[!.]* ./..?* ; do
+        [ -e "$item" ] || continue
+        mv "$item" "$DEST_DIR/"
+      done
 
       # Check if the temp dir exists in the new location, if so, move it back to db/db
       if [ -d "$DEST_DIR/$TEMP_DIR" ]; then

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -7,10 +7,9 @@ metadata:
     {{- include "questdb.labels" . | nindent 4 }}
 data:
     migrate_to_helm_v1.sh: |
-      #!/bin/bash
+      #!/bin/sh
 
-      set -e 
-      shopt -s extglob
+      set -e
 
       SOURCE_DIR="/mnt/questdb"
       DEST_DIR="db"
@@ -19,38 +18,38 @@ data:
 
       cd $SOURCE_DIR
 
-      if [[ -z $(ls $MARKER 2>/dev/null) ]] ; then
+      if [ -z "$(ls $MARKER 2>/dev/null)" ] ; then
         echo "File '$MARKER' not found. Nothing to move."
         exit 0
       fi
 
       # If the db dir already exists, move its contents to a temp dir
-      if [[ -e $DEST_DIR ]]; then
-        
-        # Check that the temp dir does not already exist. This is highly 
+      if [ -e "$DEST_DIR" ]; then
+
+        # Check that the temp dir does not already exist. This is highly
         # unlikely and we fail if this is the case
-        if [[ -e $TEMP_DIR ]]; then
+        if [ -e "$TEMP_DIR" ]; then
           echo "$TEMP_DIR exists! exiting data migration"
           exit 1
-        fi 
+        fi
 
         # Move the existing db dir to the temp location
         mv "$DEST_DIR" "$TEMP_DIR"
 
       fi
- 
-      # Make the target db dir
-      mkdir $DEST_DIR
 
-      # Move all regular files into the db dir
-      mv !($DEST_DIR) $DEST_DIR
+      # Make the target db dir
+      mkdir "$DEST_DIR"
+
+      # Move all visible files and dirs (except db) into the db dir
+      find . -maxdepth 1 ! -name '.' ! -name "$DEST_DIR" ! -name '.*' -exec mv {} "$DEST_DIR/" \;
 
       # Move any hidden files
-      mv .[^.]* "$DEST_DIR/" 2>/dev/null || true
+      find . -maxdepth 1 -name '.*' ! -name '.' ! -name '..' -exec mv {} "$DEST_DIR/" \;
 
       # Check if the temp dir exists in the new location, if so, move it back to db/db
-      if [[ -d "$DEST_DIR/$TEMP_DIR" ]]; then
-        mv $DEST_DIR/$TEMP_DIR $DEST_DIR/$DEST_DIR
+      if [ -d "$DEST_DIR/$TEMP_DIR" ]; then
+        mv "$DEST_DIR/$TEMP_DIR" "$DEST_DIR/$DEST_DIR"
       fi
 
       echo "Migration complete!"

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -19,9 +19,11 @@ data:
       cd "$SOURCE_DIR"
 
       # MARKER is a glob (tables.d.*); it must stay unquoted so the shell
-      # expands it to detect the marker file.
+      # expands it to detect the marker. -d lists each match's own name
+      # rather than a directory's contents, so an (empty) directory match
+      # still registers as "found".
       # shellcheck disable=SC2086
-      if [ -z "$(ls $MARKER 2>/dev/null)" ] ; then
+      if [ -z "$(ls -d $MARKER 2>/dev/null)" ] ; then
         echo "File '$MARKER' not found. Nothing to move."
         exit 0
       fi

--- a/charts/questdb/templates/init_db_migrations_configmap.yaml
+++ b/charts/questdb/templates/init_db_migrations_configmap.yaml
@@ -18,6 +18,9 @@ data:
 
       cd "$SOURCE_DIR"
 
+      # MARKER is a glob (tables.d.*); it must stay unquoted so the shell
+      # expands it to detect the marker file.
+      # shellcheck disable=SC2086
       if [ -z "$(ls $MARKER 2>/dev/null)" ] ; then
         echo "File '$MARKER' not found. Nothing to move."
         exit 0
@@ -43,13 +46,19 @@ data:
 
       # Move all visible files and dirs (except db) into the db dir
       for item in ./* ; do
-        [ "$(basename "$item")" = "$DEST_DIR" ] && continue
+        # Skip if the glob matched nothing (null-glob guard). -L also covers
+        # broken symlinks, which -e (it follows the link) would miss.
+        [ -e "$item" ] || [ -L "$item" ] || continue
+        if [ "$(basename "$item")" = "$DEST_DIR" ]; then
+          continue
+        fi
         mv "$item" "$DEST_DIR/"
       done
 
-      # Move any hidden files
+      # Move any hidden files, including broken symlinks (-e follows the link,
+      # so a broken symlink needs the -L check to be picked up)
       for item in ./.[!.]* ./..?* ; do
-        [ -e "$item" ] || continue
+        [ -e "$item" ] || [ -L "$item" ] || continue
         mv "$item" "$DEST_DIR/"
       done
 

--- a/charts/questdb/templates/statefulset.yaml
+++ b/charts/questdb/templates/statefulset.yaml
@@ -112,7 +112,7 @@ spec:
       initContainers:
         - name: init-db-migration
           image: "{{ .Values.dataMigration.image.repository }}:{{ .Values.dataMigration.image.tag }}"
-          command: ["bash", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
+          command: ["sh", "/mnt/migration_scripts/migrate_to_helm_v1.sh"]
           securityContext:
             {{- include "generateSecurityContext" . | nindent 12 }}
           volumeMounts:

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -134,9 +134,9 @@ serviceAccount:
 
 dataMigration:
   image:
-    repository: debian
+    repository: alpine
     pullPolicy: IfNotPresent
-    tag: 12.10-slim
+    tag: "3.21"
   resources:
     requests:
       memory: "256Mi"

--- a/charts/questdb/values.yaml
+++ b/charts/questdb/values.yaml
@@ -136,7 +136,7 @@ dataMigration:
   image:
     repository: alpine
     pullPolicy: IfNotPresent
-    tag: "3.21"
+    tag: "3.23"
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
This PR swaps the data migration init container to a much smaller `alpine` distro to reduce the potential attack surface.

Since `bash` is not installed, we needed to update the migration script to make it POSIX-compliant. 