### PR TITLE
chore: automate release

### DIFF
--- a/.github/workflows/bump_chart.yaml
+++ b/.github/workflows/bump_chart.yaml
@@ -1,0 +1,72 @@
+name: Bump Chart Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      appVersion:
+        description: 'QuestDB version (e.g. 9.3.4)'
+        required: true
+        type: string
+      chartVersion:
+        description: 'Chart version (leave empty to auto-increment patch)'
+        required: false
+        type: string
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine chart version
+        id: version
+        run: |
+          APP_VERSION="${{ inputs.appVersion }}"
+          CHART_VERSION="${{ inputs.chartVersion }}"
+
+          if [ -z "$CHART_VERSION" ]; then
+            CURRENT=$(yq '.version' charts/questdb/Chart.yaml)
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            CHART_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
+
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update Chart.yaml and values.yaml
+        run: |
+          yq -i '.version = "${{ steps.version.outputs.chart_version }}"' charts/questdb/Chart.yaml
+          yq -i '.appVersion = "${{ steps.version.outputs.app_version }}"' charts/questdb/Chart.yaml
+          yq -i '.image.tag = "${{ steps.version.outputs.app_version }}"' charts/questdb/values.yaml
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chart-update/${{ steps.version.outputs.chart_version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add charts/questdb/Chart.yaml charts/questdb/values.yaml
+          git commit -m "Bump chart to ${{ steps.version.outputs.chart_version }} (QuestDB ${{ steps.version.outputs.app_version }})"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Bump chart to ${{ steps.version.outputs.chart_version }} (QuestDB ${{ steps.version.outputs.app_version }})" \
+            --body "$(cat <<'EOF'
+          ## Summary
+          - Chart version: `${{ steps.version.outputs.chart_version }}`
+          - QuestDB version: `${{ steps.version.outputs.app_version }}`
+
+          After merging, tag to release:
+          ```
+          git tag questdb-${{ steps.version.outputs.chart_version }}
+          git push origin questdb-${{ steps.version.outputs.chart_version }}
+          ```
+          EOF
+          )"

--- a/.github/workflows/bump_chart.yaml
+++ b/.github/workflows/bump_chart.yaml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install yq
+        run: |
+          YQ_VERSION=v4.44.3
+          wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
       - name: Determine chart version
         id: version
         run: |

--- a/.github/workflows/bump_questdb_version.yaml
+++ b/.github/workflows/bump_questdb_version.yaml
@@ -1,4 +1,4 @@
-name: Bump Chart Version
+name: Bump QuestDB Version
 
 on:
   workflow_dispatch:
@@ -12,8 +12,13 @@ on:
         required: false
         type: string
 
+  pull_request:
+    types: [closed]
+    branches: [master]
+
 jobs:
   bump:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -69,10 +74,28 @@ jobs:
           - Chart version: `${{ steps.version.outputs.chart_version }}`
           - QuestDB version: `${{ steps.version.outputs.app_version }}`
 
-          After merging, tag to release:
-          ```
-          git tag questdb-${{ steps.version.outputs.chart_version }}
-          git push origin questdb-${{ steps.version.outputs.chart_version }}
-          ```
+          A tag will be created automatically when this PR is merged.
           EOF
           )"
+
+  tag:
+    if: >
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'chart-update/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create and push tag
+        run: |
+          CHART_VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
+          TAG="questdb-${CHART_VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/bump_questdb_version.yaml
+++ b/.github/workflows/bump_questdb_version.yaml
@@ -12,13 +12,8 @@ on:
         required: false
         type: string
 
-  pull_request:
-    types: [closed]
-    branches: [master]
-
 jobs:
   bump:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -69,33 +64,8 @@ jobs:
           git push origin "$BRANCH"
           gh pr create \
             --title "Bump chart to ${{ steps.version.outputs.chart_version }} (QuestDB ${{ steps.version.outputs.app_version }})" \
-            --body "$(cat <<'EOF'
-          ## Summary
-          - Chart version: `${{ steps.version.outputs.chart_version }}`
-          - QuestDB version: `${{ steps.version.outputs.app_version }}`
+            --body "## Summary
+          - Chart version: \`${{ steps.version.outputs.chart_version }}\`
+          - QuestDB version: \`${{ steps.version.outputs.app_version }}\`
 
-          A tag will be created automatically when this PR is merged.
-          EOF
-          )"
-
-  tag:
-    if: >
-      github.event_name == 'pull_request'
-      && github.event.pull_request.merged == true
-      && startsWith(github.event.pull_request.head.ref, 'chart-update/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Create and push tag
-        run: |
-          CHART_VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
-          TAG="questdb-${CHART_VERSION}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
+          Merging will trigger a release to OCI registry and GitHub Pages."

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -66,6 +66,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           REPO_DIR=$(mktemp -d)
+          git fetch origin repo:repo
           git worktree add "$REPO_DIR" repo
 
           mkdir -p "$REPO_DIR/docs"

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -7,8 +7,8 @@ env:
 
 on:
   push:
-    tags:
-      - 'questdb-*'
+    branches: [master]
+    paths: ['charts/questdb/Chart.yaml']
   workflow_dispatch:
 
 concurrency:
@@ -27,25 +27,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-            VERSION="${TAG#questdb-}"
-          fi
+          VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Validate chart version matches tag
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          CHART_VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
-          if [ "$CHART_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "::error::Chart.yaml version ($CHART_VERSION) does not match tag version (${{ steps.version.outputs.version }})"
-            exit 1
-          fi
 
       - name: Install Helm
         uses: Azure/setup-helm@v4.2.0

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -68,12 +68,19 @@ jobs:
           REPO_DIR=$(mktemp -d)
           git worktree add "$REPO_DIR" repo
 
+          mkdir -p "$REPO_DIR/docs"
           cp ./packaged/questdb-${{ steps.version.outputs.version }}.tgz "$REPO_DIR/docs/"
 
-          helm repo index \
-            --url "${{ env.HELM_REPO_URL }}" \
-            --merge "$REPO_DIR/docs/index.yaml" \
-            ./packaged
+          if [ -f "$REPO_DIR/docs/index.yaml" ]; then
+            helm repo index \
+              --url "${{ env.HELM_REPO_URL }}" \
+              --merge "$REPO_DIR/docs/index.yaml" \
+              ./packaged
+          else
+            helm repo index \
+              --url "${{ env.HELM_REPO_URL }}" \
+              ./packaged
+          fi
 
           cp ./packaged/index.yaml "$REPO_DIR/docs/index.yaml"
 

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,13 +1,19 @@
-# from https://github.com/wkbrd/docker-registry.helm/blob/main/.github/workflows/helm_release.yaml
-# Apache 2 License
-
 name: Release Charts
+
 env:
-  HELM_VERSION_TO_INSTALL: 3.14.0
-  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}
-  
+  HELM_VERSION: "3.14.0"
+  OCI_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  HELM_REPO_URL: https://helm.questdb.io/
+
 on:
+  push:
+    tags:
+      - 'questdb-*'
   workflow_dispatch:
+
+concurrency:
+  group: helm-release
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -21,15 +27,57 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: install helm
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${TAG#questdb-}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate chart version matches tag
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          CHART_VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
+          if [ "$CHART_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Chart.yaml version ($CHART_VERSION) does not match tag version (${{ steps.version.outputs.version }})"
+            exit 1
+          fi
+
+      - name: Install Helm
         uses: Azure/setup-helm@v4.2.0
         with:
-          # Version of helm
-          version: ${{ env.HELM_VERSION_TO_INSTALL }} # default is latest
+          version: ${{ env.HELM_VERSION }}
 
-      - name: publish to oci registry
+      - name: Package chart
+        run: helm package charts/questdb/ --destination ./packaged
+
+      - name: Push to OCI registry
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.repository_owner }} --password-stdin
-          helm package "${{ github.workspace }}/charts/questdb/"
-          package=`ls -t questdb-*.tgz | head -n 1`
-          helm push "${package}" oci://${{ env.GCR_IMAGE }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
+          helm push ./packaged/questdb-${{ steps.version.outputs.version }}.tgz oci://${{ env.OCI_REGISTRY }}
+
+      - name: Update GitHub Pages helm repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          REPO_DIR=$(mktemp -d)
+          git worktree add "$REPO_DIR" repo
+
+          cp ./packaged/questdb-${{ steps.version.outputs.version }}.tgz "$REPO_DIR/docs/"
+
+          helm repo index \
+            --url "${{ env.HELM_REPO_URL }}" \
+            --merge "$REPO_DIR/docs/index.yaml" \
+            ./packaged
+
+          cp ./packaged/index.yaml "$REPO_DIR/docs/index.yaml"
+
+          cd "$REPO_DIR"
+          git add docs/index.yaml "docs/questdb-${{ steps.version.outputs.version }}.tgz"
+          git commit -m "Release chart questdb-${{ steps.version.outputs.version }}"
+          git push origin repo

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -27,10 +27,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install yq
+        run: |
+          YQ_VERSION=v4.44.3
+          wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
       - name: Extract version
         id: version
         run: |
-          VERSION=$(grep '^version:' charts/questdb/Chart.yaml | awk '{print $2}')
+          VERSION=$(yq '.version' charts/questdb/Chart.yaml)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install Helm


### PR DESCRIPTION
This PR does 2 things to automate releases:

1. Moves the release process to github actions for 2 sources:
  a. GitHub Container Registries (new registry type, but requested by users)
  b. GitHub Pages  (existing registry) 
1. Adds a separate workflow that auto-cuts a new release PR based on a provided questdb version (for one-stop version upgrades)